### PR TITLE
Update theme belgrade to 2.0.x-dev and add correct config for shopping cart block.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0+",
   "require": {
     "drupal/admin_toolbar": "^2.0",
-    "drupal/belgrade": "1.x-dev",
+    "drupal/belgrade": "2.x-dev",
     "drupal/commerce": "^2.0",
     "drupal/commerce_cart_api": "^1.0",
     "drupal/commerce_cart_flyout": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0+",
   "require": {
     "drupal/admin_toolbar": "^2.0",
-    "drupal/belgrade": "2.x-dev",
+    "drupal/belgrade": "2.0.x-dev@dev",
     "drupal/commerce": "^2.0",
     "drupal/commerce_cart_api": "^1.0",
     "drupal/commerce_cart_flyout": "^1.0",

--- a/config/install/block.block.belgrade_shopping_cart.yml
+++ b/config/install/block.block.belgrade_shopping_cart.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_cart_flyout
+  theme:
+    - belgrade
+id: belgrade_shopping_cart
+theme: belgrade
+region: top_bar
+weight: -10
+provider: null
+plugin: commerce_cart
+settings:
+  id: commerce_cart
+  label: 'Shopping Cart'
+  provider: commerce_cart
+  label_display: '0'
+  use_quantity_count: false
+  dropdown: true
+  item_text: items
+visibility: {  }


### PR DESCRIPTION
1. Update theme belgrade to 2.0.x-dev
2. After updatting belgrade to 2.0.x-dev, shoppingt cart didn't be enabled and be allocated to Top Bar region, After investigation, I found demo commerce use another shopping cat from module commerce_cart_flyout, so add this config